### PR TITLE
Padronização de controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,20 @@
+import { InternalServerError, MethodNotAllowedError } from 'infra/errors'
+
+function onErrorHandler(error, req, res) {
+  const internalError = new InternalServerError({ cause: error })
+  res.status(internalError.statusCode).json(internalError)
+}
+
+function onNoMatchHandler(req, res) {
+  const publicError = new MethodNotAllowedError()
+  res.status(publicError.statusCode).json(publicError)
+}
+
+const controller = {
+  errorHandlers: {
+    onError: onErrorHandler,
+    onNoMatch: onNoMatchHandler,
+  },
+}
+
+export default controller

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from 'pg'
+import { ServiceError } from './errors'
 
 function getSSLValues() {
   if (process.env.POSTGRES_CA) {
@@ -31,8 +32,10 @@ async function query(queryObject) {
     const result = await client.query(queryObject)
     return result
   } catch (error) {
-    console.error(error)
-    throw error
+    throw new ServiceError({
+      message: 'Erro na conexão com o banco ou na query',
+      cause: error,
+    })
   } finally {
     await client?.end()
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,9 +1,46 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super('Um erro interno não esperado aconteceu.', { cause })
-    this.statusCode = 500
+    this.statusCode = statusCode || 500
     this.name = 'InternalServerError'
     this.action = 'Entre em contato com o suporte'
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    }
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || 'Serviço indisponível no momento', { cause })
+    this.statusCode = 503
+    this.name = 'ServiceError'
+    this.action = 'Verifique se o serviço está disponível'
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    }
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super('Método não permitido para este endpoint')
+    this.statusCode = 405
+    this.name = 'MethodNotAllowedError'
+    this.action =
+      'Verifique se o método HTTP enviado é válido para este endpoint'
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "^1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2099,6 +2100,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -9182,6 +9189,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10224,6 +10244,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "^1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,50 +1,58 @@
+import { createRouter } from 'next-connect'
 import database from 'infra/database'
 import migrationsRunner from 'node-pg-migrate'
 import { resolve } from 'node:path'
+import controller from 'infra/controller'
 
-async function migrations(req, res) {
-  const allowedMethods = ['GET', 'POST']
-  if (!allowedMethods.includes(req.method)) {
-    return res.status(405).json({ error: `Method ${req.method} not allowed` })
-  }
+const router = createRouter()
 
+router.get(getHandler)
+router.post(postHandler)
+
+export default router.handler(controller.errorHandlers)
+
+const defaultConfig = {
+  databaseUrl: process.env.DATA_TEST,
+  dir: resolve('infra', 'migrations'),
+  dryRun: true,
+  direction: 'up',
+  verbose: true,
+  migrationsTable: 'pgmigrations',
+}
+
+async function getHandler(req, res) {
   let dbClient
   try {
     dbClient = await database.getNewClient()
 
-    const defaultConfig = {
-      dbClient: dbClient,
-      databaseUrl: process.env.DATA_TEST,
-      dir: resolve('infra', 'migrations'),
-      dryRun: true,
-      direction: 'up',
-      verbose: true,
-      migrationsTable: 'pgmigrations',
-    }
+    const pendingMigrations = await migrationsRunner({
+      ...defaultConfig,
+      dbClient,
+    })
 
-    if (req.method === 'GET') {
-      const pendingMigrations = await migrationsRunner(defaultConfig)
-      return res.status(200).json(pendingMigrations)
-    }
-
-    if (req.method === 'POST') {
-      const migratedMigrations = await migrationsRunner({
-        ...defaultConfig,
-        dryRun: false,
-      })
-
-      if (migratedMigrations.length > 0) {
-        return res.status(201).json(migratedMigrations)
-      }
-
-      return res.status(200).json(migratedMigrations)
-    }
-  } catch (error) {
-    console.error(error)
-    throw error
+    return res.status(200).json(pendingMigrations)
   } finally {
     await dbClient.end()
   }
 }
 
-export default migrations
+async function postHandler(req, res) {
+  let dbClient
+  try {
+    dbClient = await database.getNewClient()
+
+    const migratedMigrations = await migrationsRunner({
+      ...defaultConfig,
+      dryRun: false,
+      dbClient,
+    })
+
+    if (migratedMigrations.length > 0) {
+      return res.status(201).json(migratedMigrations)
+    }
+
+    return res.status(200).json(migratedMigrations)
+  } finally {
+    await dbClient.end()
+  }
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,40 +1,53 @@
+import { createRouter } from 'next-connect'
 import database from 'infra/database.js'
-import { InternalServerError } from 'infra/errors'
+import { InternalServerError, MethodNotAllowedError } from 'infra/errors'
 
-async function status(req, res) {
-  try {
-    const updatedAt = new Date().toISOString()
-    const databaseVersionResult = await database.query('SHOW server_version;')
-    const databaseVersionValue = databaseVersionResult.rows[0].server_version
+const router = createRouter()
 
-    const databaseConnectionsResult = await database.query({
-      text: 'SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;',
-      values: [process.env.POSTGRES_DB],
-    })
-    const databaseConnectionsValue = databaseConnectionsResult.rows[0].count
+router.get(getHandler)
 
-    const databaseMaxConnectionsResult = await database.query(
-      `SHOW max_connections;`,
-    )
-    const databaseMaxConnectionsValue = parseInt(
-      databaseMaxConnectionsResult.rows[0].max_connections,
-    )
+export default router.handler({
+  onError: onErrorHandler,
+  onNoMatch: onNoMatchHandler,
+})
 
-    res.status(200).json({
-      status: 'ok',
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: databaseMaxConnectionsValue,
-          opened_connections: databaseConnectionsValue,
-        },
-      },
-    })
-  } catch (error) {
-    const publicError = new InternalServerError({ cause: error })
-    res.status(publicError.statusCode).json(publicError)
-  }
+function onErrorHandler(error, req, res) {
+  const internalError = new InternalServerError({ cause: error })
+  res.status(internalError.statusCode).json(internalError)
 }
 
-export default status
+function onNoMatchHandler(req, res) {
+  const publicError = new MethodNotAllowedError()
+  res.status(publicError.statusCode).json(publicError)
+}
+
+async function getHandler(req, res) {
+  const updatedAt = new Date().toISOString()
+  const databaseVersionResult = await database.query('SHOW server_version;')
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version
+
+  const databaseConnectionsResult = await database.query({
+    text: 'SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;',
+    values: [process.env.POSTGRES_DB],
+  })
+  const databaseConnectionsValue = databaseConnectionsResult.rows[0].count
+
+  const databaseMaxConnectionsResult = await database.query(
+    `SHOW max_connections;`,
+  )
+  const databaseMaxConnectionsValue = parseInt(
+    databaseMaxConnectionsResult.rows[0].max_connections,
+  )
+
+  res.status(200).json({
+    status: 'ok',
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: databaseMaxConnectionsValue,
+        opened_connections: databaseConnectionsValue,
+      },
+    },
+  })
+}

--- a/tests/integration/api/v1/migrations/put.test.js
+++ b/tests/integration/api/v1/migrations/put.test.js
@@ -1,0 +1,29 @@
+import orchestrator from 'tests/orchestrator'
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices()
+  await orchestrator.clearDatabase()
+})
+
+describe('PUT api/v1/migrations', () => {
+  describe('Anonymous user', () => {
+    test('Retrieving pending migrations', async () => {
+      const response = await fetch('http://localhost:3000/api/v1/migrations', {
+        method: 'PUT',
+      })
+      expect(response.status).toBe(405)
+
+      expect(response.status).toBe(405)
+
+      const responseBody = await response.json()
+
+      expect(responseBody).toEqual({
+        name: 'MethodNotAllowedError',
+        status_code: 405,
+        message: 'Método não permitido para este endpoint',
+        action:
+          'Verifique se o método HTTP enviado é válido para este endpoint',
+      })
+    })
+  })
+})

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from 'tests/orchestrator'
+
+beforeAll(async () => await orchestrator.waitForAllServices())
+
+describe('POST api/v1/status', () => {
+  describe('Anonymous user', () => {
+    test('Retrieving current system status', async () => {
+      const response = await fetch('http://localhost:3000/api/v1/status', {
+        method: 'POST',
+      })
+
+      expect(response.status).toBe(405)
+
+      const responseBody = await response.json()
+
+      expect(responseBody).toEqual({
+        name: 'MethodNotAllowedError',
+        status_code: 405,
+        message: 'Método não permitido para este endpoint',
+        action:
+          'Verifique se o método HTTP enviado é válido para este endpoint',
+      })
+    })
+  })
+})


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints /migrations e /status.
2. Adiciona 2 novos erros customizados: MethodNotAllowedError e ServiceError.
3. Faz o InternalServerError aceitar injeção do statusCode.